### PR TITLE
Removing src from logo

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "geonorge-shared-partials",
-  "version": "0.0.57",
+  "version": "0.0.58",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -102,5 +102,5 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
-  "version": "0.0.57"
+  "version": "0.0.58"
 }

--- a/src/partials/Header.html
+++ b/src/partials/Header.html
@@ -3,7 +3,7 @@
         <div class="page-top" data-ng-app="geonorge-header" ng-controller="baseController">
             <div class="logo">
                 <a ng-href="{{epiBaseUrl}}">
-                    <img ng-src="{{imageLogoPath}}" src="/dist/images/geonorge_logo_350px.svg" alt="geonorge logo" />
+                    <img ng-src="{{imageLogoPath}}" alt="geonorge logo" />
                 </a>
             </div>
 


### PR DESCRIPTION
Fjernet src på log da dette førte til at test.geonorge.no ikke brukte prod logoen istedenfor test logoen